### PR TITLE
allow for relative-paths

### DIFF
--- a/lib/promises.js
+++ b/lib/promises.js
@@ -70,8 +70,11 @@ var promises = {
     
     /* follow a url found in given element(s) */
     follow: function(context, data) {
-	var selector = this.args[0];
-	var next = this.args[1];
+        var argsIsObject = typeof this.args[0] === 'object';
+        var selector = argsIsObject ? this.args[0]['selector'] : this.args[0];
+        var relPath = argsIsObject ? this.args[0]['relPath'] : '';
+        var next = this.args[1];
+        
         var self = this;
         var res = context.find(selector);
         
@@ -85,6 +88,7 @@ var promises = {
 		else
                     var val = getURL(el);
                 if (val !== null) {
+                    val = require('path').join(relPath, val);
                     var url = URL.resolve(context.doc().request.url, val);
                     if (!url) return;
                     self.log("url: "+url)
@@ -386,8 +390,8 @@ promises.post.preloader = function(args) {
 
 promises.follow.preloader = function(args) {
     var type = typeof args[0];
-    if (type === 'string' || args[0] instanceof String) {
-    
+    if ((type === 'string' || args[0] instanceof String)
+       || (type === 'object' && args[0]['relPath'] && args[0]['selector'])) {
     }else if (type === 'object') {
         args[2] = args[0];
         args[0] = undefined;


### PR DESCRIPTION
can now do 

.follow({selector: '@href', relPath: 'www.examine.com'})

to handle relative paths without the base url e.g. '/supplement/caffeine'