### PR TITLE
Fixing submit checkbox case

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,10 @@
 #Osmosis
 
+HTML/XML parser and web scraper for NodeJS.
+
 [![NPM](https://nodei.co/npm/osmosis.png)](https://www.npmjs.com/package/osmosis)
 
 [![Build Status](https://travis-ci.org/rc0x03/node-osmosis.svg)](https://travis-ci.org/rc0x03/node-osmosis)
-
-HTML/XML parser and web scraper for NodeJS.
 
 ##Features
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 #Osmosis
 
+[![NPM](https://nodei.co/npm/osmosis.png)](https://www.npmjs.com/package/osmosis)
+
 [![Build Status](https://travis-ci.org/rc0x03/node-osmosis.svg)](https://travis-ci.org/rc0x03/node-osmosis)
 
 HTML/XML parser and web scraper for NodeJS.
@@ -42,12 +44,6 @@ osmosis
 .log(console.log)
 .error(console.log)
 .debug(console.log)
-```
-
-##Install
-
-```
-npm install osmosis
 ```
 
 ##Documentation

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -477,9 +477,9 @@ var Promise = {
                 }
             } else if (elName === 'textarea') {
                 params[name] = input.content();
-            } else if (elName === 'checkbox') {
-                params[name] = input.attr('checked');
-            } else if (elName === 'input') {
+            } else if (input.attr('type') === 'checkbox' && input.attr('checked')) {
+                params[name] = input.attr('value') || 'on';
+            } else if (elName === 'input' && input.attr('type') !== 'checkbox') {
                 params[name] = input.attr('value');
             }
         })


### PR DESCRIPTION
There is no element called \<checkbox\>, it is a type of regular inputs (\<input type=checkbox\>), and if is not checked browsers do not submit that value, and when it is checked it should send the `value` attribute, or if it doesn't have any it should send the value "on" as web browsers do.